### PR TITLE
Novo comando csvfilter

### DIFF
--- a/pybr/__main__.py
+++ b/pybr/__main__.py
@@ -1,0 +1,28 @@
+import csv
+import sys
+
+import click
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.option("-c", "--columns", type=click.File("r"), help="File with columns to keep")
+@click.option("csvout", "--out", default=sys.stdout, type=click.File("w"), help="Save output to file")
+@click.argument("file", type=click.File("r"))
+def csvfilter(file, csvout, columns):
+    columns_to_keep = [c.strip() for c in columns.readlines()]
+
+    reader = csv.DictReader(file)
+    writer = csv.DictWriter(csvout, fieldnames=columns_to_keep)
+    writer.writeheader()
+
+    for row in reader:
+        writer.writerow({column: row[column] for column in columns_to_keep})
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
`csvfilter` será usado para anonimizar o formulário de submissão de atividades. Primeiro filtro que implementei foi o de colunas.

Exemplo de como usar:

```
$ python -m pybr csvfilter -c colunas.txt submissões.csv > submissões-para-revisão.csv
```


Arquivo `colunas.txt` contém a lista de colunas que deverão permanecer no `.csv` resultante, por exemplo:
```
Descrição completa para avaliação:
Conteúdo da palestra:
O que sua palestra agregará?
```